### PR TITLE
Updated Website_Analyzer.py

### DIFF
--- a/Website_Analyzer.py
+++ b/Website_Analyzer.py
@@ -22,7 +22,7 @@ config = {'forms': True, 'comments': True, 'passwords': True }	#default config o
 if(args.config):
 	print('Using config file: ' + args.config)
 	config_file = open(args.config, 'r')
-	config_from_file = yaml.load(config_file)
+	config_from_file = yaml.safe_load(config_file)
 	if(config_from_file):
 		config = { **config, **config_from_file }		
 report = ''


### PR DESCRIPTION
Missing positional argument 'Loader', possibly because of some sort of change in the PyYAML API which it requires 'Loader' argument! you can fix this code byt changing yaml.load(config_file) to yaml.safe_load() instead. THis will ensure safe loading of YAML file content and resolves any other Errors